### PR TITLE
Fix dev container startup failure.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,13 +9,14 @@ RUN sudo apt-get update && sudo apt-get install -y \
     pkg-config \
     libdbus-1-dev \
     libglib2.0-dev \
- && python -m pip install --upgrade pip \
- && sudo apt-get clean \
- && sudo rm -rf /var/lib/apt/lists/*
+    && python -m pip install --upgrade pip \
+    && sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/*
 
 # Copy requirements.txt and install the Python packages
 # Install keyring-related and IPython packages in the same layer to reduce the image size and build time
 COPY requirements.txt .
+COPY ./hack-resources/azure_core-1.31.0-py3-none-any.whl ./hack-resources/azure_core-1.31.0-py3-none-any.whl
 RUN pip install -r requirements.txt \
     && pip install keyrings.alt dbus-python ipython ipykernel
 


### PR DESCRIPTION
This pull request includes a small change to the `.devcontainer/Dockerfile` to add a new dependency. The change ensures that the `azure_core` package is available during the build process.

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R19): Added a new `azure_core` package to the build process by copying the wheel file into the container.