### PR TITLE
Launch standalone Aspire dashboard.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start Aspire Dashboard",
+            "type": "shell",
+            "command": "./start-aspire-dashboard.sh",
+            "problemMatcher": []
+        },
+        {
+            "label": "Stop Aspire Dashboard",
+            "type": "shell",
+            "command": "docker stop aspire-dashboard",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/start-aspire-dashboard.sh
+++ b/start-aspire-dashboard.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Start the Aspire Dashboard.
+docker run --rm -it -p 18888:18888 -p 4317:18889 -d --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:8.1.0
+
+# Wait for the Aspire Dashboard to start.
+sleep 7 
+
+# Get the last 15 lines of the Aspire Dashboard logs.
+docker logs --tail 15 aspire-dashboard
+
+# Prompt the user to copy the token from the logs.
+echo "Copy the token from the logs above."
+
+# Wait for the user to confirm that they have copied the token
+read -p "Press enter to continue and launch the Aspire Dashboard in the default browser."
+
+# Open the Aspire Dashboard in the default browser.
+xdg-open http://localhost:18888


### PR DESCRIPTION
This pull request introduces a new task configuration for VS Code and a script to manage the Aspire Dashboard. The most significant changes include adding tasks to start and stop the Aspire Dashboard and creating a script to run and manage the Aspire Dashboard container.

### Task Configuration:

* `.vscode/tasks.json`: Added tasks to start and stop the Aspire Dashboard using shell commands.

### Script for Aspire Dashboard:

* `start-aspire-dashboard.sh`: Added a script to run the Aspire Dashboard container, monitor its logs, prompt the user for a token, and open the dashboard in the default browser.